### PR TITLE
Task memory leak

### DIFF
--- a/src/main/java/br/com/labbs/monitor/MonitorMetrics.java
+++ b/src/main/java/br/com/labbs/monitor/MonitorMetrics.java
@@ -84,6 +84,9 @@ public enum MonitorMetrics {
 
         initialized = true;
     }
+    public void cancelAllDependencyCheckers(){
+        dependencyCheckerExecutor.cancelTasks();
+    }
 
     /**
      * Add dependency to be checked successive between the period
@@ -105,5 +108,5 @@ public enum MonitorMetrics {
         };
         dependencyCheckerExecutor.schedule(task, period);
     }
-
+ 
 }

--- a/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutor.java
+++ b/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutor.java
@@ -11,6 +11,10 @@ public class DependencyCheckerExecutor {
     public DependencyCheckerExecutor() {
        timer = new Timer("monitor-metrics-dependency-checker");
     }
+    public void cancelTasks(){
+        timer.cancel();
+        timer.purge();
+    }
 
     /**
      * Schedules the specified task for repeated <i>fixed-rate execution period</i>.


### PR DESCRIPTION
Possível correção para issue https://github.com/labbsr0x/servlet-monitor/issues/7

Amostra usando listener para cancelar DependencyChecker para servlet-api:

```java
...
    public void contextDestroyed(ServletContextEvent sce) {
        MonitorMetrics.INSTANCE.cancelAllDependencyCheckers();
    }
...
```