### PR TITLE
Task executor changed

### DIFF
--- a/src/main/java/br/com/labbs/monitor/MonitorMetrics.java
+++ b/src/main/java/br/com/labbs/monitor/MonitorMetrics.java
@@ -2,6 +2,7 @@ package br.com.labbs.monitor;
 
 import br.com.labbs.monitor.dependency.DependencyChecker;
 import br.com.labbs.monitor.dependency.DependencyCheckerExecutor;
+import br.com.labbs.monitor.dependency.DependencyCheckerFactory;
 import br.com.labbs.monitor.dependency.DependencyState;
 import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Counter;
@@ -57,7 +58,7 @@ public enum MonitorMetrics {
     public Gauge dependencyUp;
     public Gauge applicationInfo;
 
-    private DependencyCheckerExecutor dependencyCheckerExecutor = new DependencyCheckerExecutor();
+    private DependencyCheckerExecutor dependencyCheckerExecutor = DependencyCheckerFactory.create();
 
     private boolean noBuckets = false;
     private boolean initialized;

--- a/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutor.java
+++ b/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutor.java
@@ -8,23 +8,13 @@ import java.util.TimerTask;
  *
  * @see DependencyChecker
  */
-public class DependencyCheckerExecutor {
-    private static final long START_DELAY_MILLIS = 10000L;
-
-    private Timer timer;
-
-    public DependencyCheckerExecutor() {
-        timer = new Timer("monitor-metrics-dependency-checker");
-    }
+public interface DependencyCheckerExecutor {
 
     /**
      * Terminates the executor timer, discarding any currently scheduled tasks.
      * Removes all cancelled tasks from the executor timer's task queue.
      */
-    public void cancelTasks() {
-        timer.cancel();
-        timer.purge();
-    }
+    public void cancelTasks();
 
     /**
      * Schedules the specified task for repeated <i>fixed-rate execution period</i>.
@@ -32,7 +22,5 @@ public class DependencyCheckerExecutor {
      * @param task   task to be executed
      * @param period time in milliseconds between successive task executions.
      */
-    public void schedule(final TimerTask task, final long period) {
-        timer.scheduleAtFixedRate(task, START_DELAY_MILLIS, period);
-    }
+    public void schedule(final TimerTask task, final long period);
 }

--- a/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutorService.java
+++ b/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutorService.java
@@ -1,0 +1,55 @@
+package br.com.labbs.monitor.dependency;
+
+import java.util.TimerTask;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Executes scheduled dependency checkers with ScheduledExecutorService.
+ *
+ * @see DependencyChecker
+ */
+public class DependencyCheckerExecutorService implements DependencyCheckerExecutor {
+    private static final long START_DELAY_MILLIS = 10000L;
+
+    private ScheduledExecutorService service;
+
+    public DependencyCheckerExecutorService() {
+        service = Executors.newScheduledThreadPool(5);
+    }
+    public DependencyCheckerExecutorService(String jndiName)  {
+        try {
+            ScheduledExecutorService executor
+                    = (ScheduledExecutorService) new InitialContext().lookup(jndiName);
+            
+            service = executor;
+        } catch (NamingException ex) {
+            service = Executors.newScheduledThreadPool(5);
+        }
+    }
+
+    @Override
+    public void cancelTasks() {
+        service.shutdown();
+        try {
+            service.awaitTermination(START_DELAY_MILLIS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            
+        }
+    }
+
+    @Override
+    public void schedule(final TimerTask task, final long period) {
+        service.scheduleAtFixedRate(task, START_DELAY_MILLIS, period, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public String toString() {
+        return "DependencyCheckerExecutorService with: " + service;
+    }
+    
+    
+}

--- a/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutorTimerTask.java
+++ b/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerExecutorTimerTask.java
@@ -1,0 +1,30 @@
+package br.com.labbs.monitor.dependency;
+
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Executes scheduled dependency checkers with TimerTask.
+ *
+ * @see DependencyChecker
+ */
+public class DependencyCheckerExecutorTimerTask implements DependencyCheckerExecutor {
+    private static final long START_DELAY_MILLIS = 10000L;
+
+    private Timer timer;
+
+    public DependencyCheckerExecutorTimerTask() {
+        timer = new Timer("monitor-metrics-dependency-checker");
+    }
+
+    @Override
+    public void cancelTasks() {
+        timer.cancel();
+        timer.purge();
+    }
+
+    @Override
+    public void schedule(final TimerTask task, final long period) {
+        timer.scheduleAtFixedRate(task, START_DELAY_MILLIS, period);
+    }
+}

--- a/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerFactory.java
+++ b/src/main/java/br/com/labbs/monitor/dependency/DependencyCheckerFactory.java
@@ -1,0 +1,53 @@
+package br.com.labbs.monitor.dependency;
+
+import br.com.labbs.monitor.util.PropertiesUtil;
+
+public class DependencyCheckerFactory {
+
+    private DependencyCheckerFactory() {
+        // not intanciate this
+    }
+
+    /**
+     * The factory uses properties file to create DependencyCheckerExecutor
+     * impplementation.
+     *
+     * <p>
+     * Params in application.properties:</p>
+     *
+     * <ul>
+     * <li>application.executor.implementation=[TimerTask|ScheduledExecutorService]</li>
+     * <li>application.executor.jndiname=[JNDI name to lookup
+     * ScheduledExecutorService]</li>
+     * </ul>
+     *
+     * @return the @{@link DependencyCheckerExecutor} implementation
+     */
+    public static DependencyCheckerExecutor create() {
+        String executorImplementation = getExecutorImplementationFromPropertiesFile();
+
+        DependencyCheckerExecutor executor;
+
+        if ("TimerTask".equals(executorImplementation)) {
+            executor = new DependencyCheckerExecutorTimerTask();
+        } else if ("ScheduledExecutorService".equals(executorImplementation)) {
+            String jndiName = getExecutorServiceJndiNameFromPropertiesFile();
+            if ("unknown".equals(jndiName)) {
+                executor = new DependencyCheckerExecutorService();
+            } else {
+                executor = new DependencyCheckerExecutorService(jndiName);
+            }
+        } else {
+            executor = new DependencyCheckerExecutorTimerTask();
+        }
+        return executor;
+    }
+
+    private static String getExecutorImplementationFromPropertiesFile() {
+        return PropertiesUtil.getValueFromPropertiesFile("application.executor.implementation");
+    }
+
+    private static String getExecutorServiceJndiNameFromPropertiesFile() {
+        return PropertiesUtil.getValueFromPropertiesFile("application.executor.jndiname");
+    }
+}

--- a/src/main/java/br/com/labbs/monitor/util/PropertiesUtil.java
+++ b/src/main/java/br/com/labbs/monitor/util/PropertiesUtil.java
@@ -1,0 +1,32 @@
+package br.com.labbs.monitor.util;
+
+import br.com.labbs.monitor.filter.DebugUtil;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PropertiesUtil {
+
+    private PropertiesUtil() {
+        // not intanciate this
+    }
+    
+    public static String getValueFromPropertiesFile(String key) {
+        return getValueFromPropertiesFile(key, "unknown") ;
+    }
+    
+    public static String getValueFromPropertiesFile(String key, String defaulValue) {
+        try {
+            final Properties p = new Properties();
+            final InputStream is = PropertiesUtil.class.getResourceAsStream("/application.properties");
+            if (is != null) {
+                p.load(is);
+                //TODO check property existence
+                return p.getProperty(key);
+            }
+            return defaulValue;
+        } catch (Exception e) {
+            DebugUtil.debug("error reading version from application.properties file: ", e.getMessage());
+            return "error-reading-version";
+        }
+    }
+}


### PR DESCRIPTION
An error occurred when running DependencyChecker with WebSphere Liberty to check the JPA connection.


> CWNEN1000E: A JNDI operation on a java:comp/env name cannot be completed because the current thread is not associated with a Java Enterprise Edition application component. This condition can occur when the JNDI client using the java:comp/env name does not occur on the thread of a server application request. Make sure that a Java EE application does not run JNDI operations on java:comp/env names within static code blocks or in threads created by that application. Such code does not necessarily run on the thread of a server application request and therefore is not supported by JNDI operations on java:comp/env names.]


Similar issue with Quartz Scheduler

See:

- https://www.ibm.com/support/pages/spawning-new-thread-j2ee-application-thread-do-jndi-lookup-not-supported
- http://sureshgarrepalli.blogspot.com/2015/08/customizing-quartz-to-use-server.html?view=classic
- https://gybas.com/2014/quartz-websphere-spring/