### PR TITLE
Migrate from javax to jakarta servlet API and update dependencies

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.6.1/apache-maven-3.6.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,14 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.0</version>
+                <configuration>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                </configuration>
+            </plugin>
+            <plugin>
                 <executions>
                     <execution>
                         <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>br.com.labbs</groupId>
     <artifactId>servlet-monitor</artifactId>
-    <version>0.1.4-SNAPSHOT</version>
+    <version>0.2.0</version>
     <packaging>jar</packaging>
 
     <name>servlet-monitor</name>
@@ -44,11 +45,12 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <prometheus.version>0.8.0</prometheus.version>
-        <maven-source-plugin.version>2.2.1</maven-source-plugin.version>
-        <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
-        <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
-        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
-        <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
+        <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
+        <maven-javadoc-plugin.version>3.11.2</maven-javadoc-plugin.version>
+        <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
+        <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+        <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     </properties>
 
     <dependencies>
@@ -71,9 +73,9 @@
             <version>${prometheus.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.1.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- Test -->
@@ -94,15 +96,15 @@
     <build>
         <plugins>
             <plugin>
-              <configuration>
-                <serverId>ossrh</serverId>
-                <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              </configuration>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <extensions>true</extensions>
-              <groupId>org.sonatype.plugins</groupId>
-              <version>1.6.7</version>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                </configuration>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <groupId>org.sonatype.plugins</groupId>
+                <version>1.6.7</version>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -122,65 +124,56 @@
                 </configuration>
             </plugin>
             <plugin>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <artifactId>maven-source-plugin</artifactId>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>${maven-source-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>${maven-javadoc-plugin.version}</version>
+            </plugin>
+            <plugin>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <optimize>true</optimize>
+                    <debug>true</debug>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
                 </configuration>
-            </plugin>
-            <plugin>
-              <executions>
-                <execution>
-                  <id>attach-sources</id>
-                  <goals>
-                    <goal>jar-no-fork</goal>
-                  </goals>
-                </execution>
-              </executions>
-              <artifactId>maven-source-plugin</artifactId>
-              <groupId>org.apache.maven.plugins</groupId>
-              <version>2.2.1</version>
-            </plugin>
-            <plugin>
-              <executions>
-                <execution>
-                  <id>attach-javadocs</id>
-                  <goals>
-                    <goal>jar</goal>
-                  </goals>
-                </execution>
-              </executions>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <groupId>org.apache.maven.plugins</groupId>
-              <version>3.2.0</version>
-            </plugin>
-            <plugin>
-              <configuration>
-                <optimize>true</optimize>
-                <debug>true</debug>
-                <showDeprecation>true</showDeprecation>
-                <showWarnings>true</showWarnings>
-              </configuration>
-              <artifactId>maven-compiler-plugin</artifactId>
-              <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>${maven-compiler-plugin.version}</version>
             </plugin>
 
             <plugin>
-              <executions>
-                <execution>
-                  <id>sign-artifacts</id>
-                  <phase>verify</phase>
-                  <goals>
-                    <goal>sign</goal>
-                  </goals>
-                </execution>
-              </executions>
-              <artifactId>maven-gpg-plugin</artifactId>
-              <groupId>org.apache.maven.plugins</groupId>
-              <version>1.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>${maven-gpg-plugin.version}</version>
             </plugin>
         </plugins>
     </build>
@@ -217,7 +210,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/src/main/java/br/com/labbs/monitor/exporter/MetricsServlet.java
+++ b/src/main/java/br/com/labbs/monitor/exporter/MetricsServlet.java
@@ -2,10 +2,10 @@ package br.com.labbs.monitor.exporter;
 
 import br.com.labbs.monitor.MonitorMetrics;
 import io.prometheus.client.exporter.common.TextFormat;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.Writer;
 
@@ -16,7 +16,7 @@ public class MetricsServlet extends HttpServlet {
 
     /**
      * {@inheritDoc}
-     * {@link javax.servlet.http.HttpServlet#doGet(HttpServletRequest, HttpServletResponse)}
+     * {@link HttpServlet#doGet(HttpServletRequest, HttpServletResponse)}
      */
     @Override
     protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {
@@ -34,7 +34,7 @@ public class MetricsServlet extends HttpServlet {
 
     /**
      * {@inheritDoc}
-     * {@link javax.servlet.http.HttpServlet#doPost(HttpServletRequest, HttpServletResponse)}
+     * {@link HttpServlet#doPost(HttpServletRequest, HttpServletResponse)}
      */
     @Override
     protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws IOException {

--- a/src/main/java/br/com/labbs/monitor/filter/CountingServletOutputStream.java
+++ b/src/main/java/br/com/labbs/monitor/filter/CountingServletOutputStream.java
@@ -1,6 +1,8 @@
 package br.com.labbs.monitor.filter;
 
-import javax.servlet.ServletOutputStream;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.WriteListener;
+
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -12,8 +14,10 @@ import java.io.OutputStream;
 public class CountingServletOutputStream extends ServletOutputStream {
 
     private final CountingOutputStream output;
+    private final ServletOutputStream servletOutputStream;
 
     public CountingServletOutputStream(ServletOutputStream output) {
+        this.servletOutputStream = output;
         this.output = new CountingOutputStream(output);
         DebugUtil.debug("CountingServletOutputStream init");
     }
@@ -34,6 +38,26 @@ public class CountingServletOutputStream extends ServletOutputStream {
     @Override
     public void flush() throws IOException {
         output.flush();
+    }
+
+    /**
+     * {@inheritDoc}
+     * {@link ServletOutputStream#isReady()} ()}
+     */
+    @Override
+    public boolean isReady() {
+        // Delegate isReady to the actual ServletOutputStream
+        return servletOutputStream.isReady();
+    }
+
+    /**
+     * {@inheritDoc}
+     * {@link ServletOutputStream#setWriteListener(WriteListener)} ()}
+     */
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        // Delegate setWriteListener to the actual ServletOutputStream
+        servletOutputStream.setWriteListener(writeListener);
     }
 
     /**

--- a/src/main/java/br/com/labbs/monitor/filter/CountingServletResponse.java
+++ b/src/main/java/br/com/labbs/monitor/filter/CountingServletResponse.java
@@ -1,8 +1,9 @@
 package br.com.labbs.monitor.filter;
 
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponseWrapper;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 

--- a/src/main/java/br/com/labbs/monitor/filter/MetricsCollectorFilter.java
+++ b/src/main/java/br/com/labbs/monitor/filter/MetricsCollectorFilter.java
@@ -7,18 +7,12 @@ import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import br.com.labbs.monitor.MonitorMetrics;
 import io.prometheus.client.SimpleTimer;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
 /**
  * The MetricsFilter class provides a high-level filter that enables collection of (latency, amount and response
  * size metrics) for Servlet performance, based on schema, status code, HTTP method and URI path.

--- a/src/test/java/br/com/labbs/monitor/exporter/MetricsServletTest.java
+++ b/src/test/java/br/com/labbs/monitor/exporter/MetricsServletTest.java
@@ -2,6 +2,8 @@ package br.com.labbs.monitor.exporter;
 
 import br.com.labbs.monitor.MonitorMetrics;
 import io.prometheus.client.Gauge;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.hamcrest.CoreMatchers;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -9,8 +11,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;


### PR DESCRIPTION
Migrated all imports from `javax.servlet` to `jakarta.servlet` to align with Jakarta EE standards. Updated Maven dependencies to use Jakarta artifacts and upgraded plugin and library versions for compatibility and enhanced functionality. Maven wrapper updated to use Maven 3.9.9.

closes #38 